### PR TITLE
fix: enable sample_steps > num_gpus_dit with modulo cycling

### DIFF
--- a/liveavatar/models/wan/causal_s2v_pipeline_tpp.py
+++ b/liveavatar/models/wan/causal_s2v_pipeline_tpp.py
@@ -1048,13 +1048,31 @@ class WanS2V:
                         }
 
                     for i, t in enumerate(tqdm(timesteps)):
-                        if i != dist.get_rank():
+                        # Modulo cycling: step i runs on rank (i % num_gpus_dit)
+                        my_rank = dist.get_rank()
+                        if my_rank >= num_gpus_dit:
+                            # VAE rank skips all denoising steps
                             continue
-                        if self.src_gpu is None:
-                            latent_model_input = block_latents #[16,num_frames_per_block,h,w]
-                        else:  
-                            latent_model_input = torch.empty_like(block_latents)  # 创建空tensor接收
+                        if i % num_gpus_dit != my_rank:
+                            continue
+
+                        # Dynamic source: first step of each cycle starts fresh or receives from last DiT rank
+                        is_first_in_cycle = (i % num_gpus_dit == 0)
+                        is_very_first_step = (i == 0)
+
+                        if is_very_first_step:
+                            # Very first step: use initial block_latents
+                            latent_model_input = block_latents
+                        elif is_first_in_cycle:
+                            # Start of new cycle: receive from last DiT rank (rank num_gpus_dit-1)
+                            latent_model_input = torch.empty_like(block_latents)
+                            dist.recv(latent_model_input, num_gpus_dit - 1)
+                        elif self.src_gpu is not None:
+                            # Normal step in cycle: receive from previous rank
+                            latent_model_input = torch.empty_like(block_latents)
                             dist.recv(latent_model_input, self.src_gpu)
+                        else:
+                            latent_model_input = block_latents
 
                         timestep = [t] * self.num_frames_per_block
                         timestep = torch.tensor(timestep).to(self.device).unsqueeze(0)
@@ -1069,6 +1087,8 @@ class WanS2V:
 
                         noise_pred = [torch.cat(noise_pred_cond, dim=0)]
 
+                        # Update scheduler step index for modulo cycling
+                        sample_scheduler._step_index = i
                         temp_x0 = sample_scheduler.step(
                             noise_pred[0].unsqueeze(0),# [16,f,h,w]
                             t,
@@ -1076,9 +1096,20 @@ class WanS2V:
                             return_dict=False,
                             generator=seed_g)[0]
                         block_latents = temp_x0.squeeze(0) #[16,num_frames_per_block,h,w]
-                        if self.tgt_gpu is None:
-                            pass
-                        else:
+
+                        # Dynamic target: last rank in cycle sends to rank 0, unless it's the final step
+                        is_last_in_cycle = (my_rank == num_gpus_dit - 1)
+                        is_final_step = (i == len(timesteps) - 1)
+
+                        if is_final_step:
+                            # Final step: send to VAE rank
+                            if self.tgt_gpu is not None:
+                                dist.send(block_latents.contiguous(), self.tgt_gpu)
+                        elif is_last_in_cycle:
+                            # End of cycle but not final: send to rank 0 for next cycle
+                            dist.send(block_latents.contiguous(), 0)
+                        elif self.tgt_gpu is not None and self.tgt_gpu < num_gpus_dit:
+                            # Normal step: send to next rank (but not to VAE)
                             dist.send(block_latents.contiguous(), self.tgt_gpu)
  
                     if enable_vae_parallel and dist.get_rank() == num_gpus_dit-1+int(enable_vae_parallel):


### PR DESCRIPTION
## Problem

Multi-GPU inference crashes when `sample_steps > num_gpus_dit`:
- `--sample_steps 8` with `--num_gpus_dit 4` causes `KeyError: 'cond_shape'` or `KeyError: '5'`

**Root cause:** The denoising loop maps step `i` directly to rank `i` (`if i != dist.get_rank(): continue`), so steps 4+ have no GPU to run them.

## Solution

Implement modulo cycling so steps wrap around available GPUs:
- Steps 0,4,8,12 → Rank 0
- Steps 1,5,9,13 → Rank 1
- Steps 2,6,10,14 → Rank 2
- Steps 3,7,11,15 → Rank 3

### Changes:
1. **Modulo cycling:** `if i % num_gpus_dit != my_rank` instead of `if i != dist.get_rank()`
2. **Dynamic send/recv:** Last rank in cycle sends to rank 0 (not VAE), final step sends to VAE
3. **Scheduler fix:** Set `sample_scheduler._step_index = i` for correct timestep handling
4. **kv_cache init:** Initialize for all ranks including VAE to avoid KeyError
5. **KV cache sync:** Broadcast KV cache from the GPU that completed each step to all other DiT GPUs

### Why KV cache sync is needed

With modulo cycling, each GPU maintains its own KV cache. The denoising loop processes the same temporal block across all steps, with each step **overwriting** the same cache positions:

| Step | GPU | GPU's KV Cache |
|------|-----|----------------|
| 0 | GPU 0 | writes [X:X+len] |
| 1 | GPU 1 | overwrites [X:X+len] |
| 2 | GPU 2 | overwrites [X:X+len] |
| 3 | GPU 3 | overwrites [X:X+len] |
| 4 | GPU 0 | has stale values from step 0! |

Without sync, GPU 0 at step 4 reads stale KV values from step 0 instead of step 3's values. This breaks temporal attention alignment, causing lipsync drift.

The fix broadcasts the updated KV cache after each step using `dist.send/recv`.

## Testing

Tested on 5 GPUs (4 DiT + 1 VAE) with:
- `--sample_steps 8`
- `--sample_steps 16`

Video quality improved with more denoising steps as expected.